### PR TITLE
Serving index.html by default

### DIFF
--- a/docs/_data/sidebars/home_sidebar.yml
+++ b/docs/_data/sidebars/home_sidebar.yml
@@ -63,8 +63,14 @@ entries:
       url: /#writing-your-own-template-renderer
       output: web
   - title: Serving static files
-    url: /#serving-static-files
     output: web
+    folderitems:
+      - title: Basics
+        url: /#serving-static-files
+        output: web
+      - title: Serving index.html by default
+        url: /#serving-indexhtml-at--by-default
+        output: web
   - title: Plugins
     url: /#plugins
     output: web

--- a/docs/index.md
+++ b/docs/index.md
@@ -537,6 +537,24 @@ public class AppResource extends FileResource {
 
 Your files will then be accessible from the `/webroot/` path prefix.
 
+### Serving `index.html` at `/` by default
+
+Usually web servers do this by default.
+
+{% highlight java %}
+@Path("/{path:(.*)?}")
+public class AppResource extends FileResource {
+
+  @GET
+  public Response index(@PathParam("path") String path) throws IOException {
+    return super.getFile(path.equals("") ? "index.html" : path);
+  }
+}
+{% endhighlight %}
+
+Your home page will then be accessible from the root path (eg: [http://localhost:9000](http://localhost:9000)).
+
+
 ## Plugins
 
 You can write plugins by declaring a `META-INF/services/net.redpipe.engine.spi.Plugin` file in your


### PR DESCRIPTION
I would like to add a snippet explaining how to serve `index.html` by default at the `/` prefix